### PR TITLE
Analyze all DragAndDrop files/folders before throwing exception(s) and aborting.

### DIFF
--- a/ilSFV/InvalidChecksumFileException.cs
+++ b/ilSFV/InvalidChecksumFileException.cs
@@ -8,12 +8,16 @@ namespace ilSFV
 {
     class InvalidChecksumFileException : Exception
     {
+        private string _fileName;
+        public string FileName { get { return _fileName; } }
+
         // TODO: Localize "Line"
         public InvalidChecksumFileException(string fileName, ChecksumType checksumType, string[] lines, int lineIndex, int codePage)
             : base(string.Format("Line {0}: \"{1}\"", lineIndex + 1, lines[lineIndex]) + Environment.NewLine + Environment.NewLine +
                    string.Format(Language.MainForm.FileContentsNotRecognized, fileName, checksumType, File.ReadAllText(fileName, Encoding.GetEncoding(codePage)))
             )
         {
+            _fileName = fileName;
         }
     }
 }


### PR DESCRIPTION
Default "checking" behavior throws exceptions upon encountering the
first invalid checksum file and does not provide user with the path of
the invalid checksum file in the exception message. Most users would
prefer seeing a complete listing of all checksum files that need to be
repaired/replaced in one drag and drop operation. New functionality
traverses all files in the drag and drop selection before throwing a
final exception containing a complete listing of bad checksum files.
